### PR TITLE
Misc enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@dsnp/frequency-schemas": "^1.1.0",
-        "@dsnp/graph-sdk": "^1.0.3",
+        "@dsnp/graph-sdk": "^1.1.1",
         "@frequency-chain/api-augment": "^1.11.1",
         "@polkadot/api": "^10.12.4",
         "@polkadot/keyring": "^12.6.2",
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/@dsnp/graph-sdk": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@dsnp/graph-sdk/-/graph-sdk-1.0.3.tgz",
-      "integrity": "sha512-3G1I/TuvLiBEVISoz/+wv6fKjsA516Zg3/MgqDOa1dRnKhK+6XE4qwDK+tmMIGiC3m0h6Sj5cK3mhCeH+pmnfQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@dsnp/graph-sdk/-/graph-sdk-1.1.1.tgz",
+      "integrity": "sha512-9HCa5OkPvyOy7rESp/iMaH7XHiKsFUmEzCVQ6TAXB9upEiDJZOjLv8cd0UP8YyBIXYquqvtSr0MNBqpFoXk4jQ==",
       "engines": {
         "node": "^14.0.0 || ^16.0.0 || >=17.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.js",
-  "files": ["/dist"],
+  "files": [
+    "/dist"
+  ],
   "scripts": {
     "prepare": "npm run build",
     "build": "tsc && node scripts/package.cjs",
@@ -27,7 +29,7 @@
   "homepage": "https://github.com/AmplicaLabs/frequency-scenario-template#readme",
   "dependencies": {
     "@dsnp/frequency-schemas": "^1.1.0",
-    "@dsnp/graph-sdk": "^1.0.3",
+    "@dsnp/graph-sdk": "^1.1.1",
     "@frequency-chain/api-augment": "^1.11.1",
     "@polkadot/api": "^10.12.4",
     "@polkadot/keyring": "^12.6.2",

--- a/src/examples/read-graph.ts
+++ b/src/examples/read-graph.ts
@@ -20,12 +20,14 @@ import {
   Update,
   KeyData,
   ImportBundle,
+  GraphKeyPair,
+  GraphKeyType,
 } from '@dsnp/graph-sdk';
 import { firstValueFrom } from 'rxjs';
-import log from 'loglevel';
-import { PaginatedStorageResponse, SchemaId } from '@frequency-chain/api-augment/interfaces';
+import log, { enableAll } from 'loglevel';
+import { ItemizedStoragePageResponse, PaginatedStorageResponse, SchemaId } from '@frequency-chain/api-augment/interfaces';
 import { User } from '#app/scaffolding/user';
-import { assert } from '@polkadot/util';
+import { assert, hexToU8a } from '@polkadot/util';
 import { Option } from '@polkadot/types';
 import { PalletCapacityCapacityDetails } from '@polkadot/types/lookup';
 import minimist from 'minimist';
@@ -48,20 +50,31 @@ function getTestConfig(schemaMap: { [key: number]: SchemaConfig }, keySchemaId: 
 
 async function main() {
   // Extract any CLI arguments
-  const argv = minimist(process.argv);
-  const { msaId } = argv;
+  const argv = minimist(process.argv, { string: ['publicGraphKeyHex', 'privateGraphKeyHex', 'msaId'] });
+  const { msaId, publicGraphKeyHex, privateGraphKeyHex } = argv;
 
   // Connect to chain & initialize API
   await initialize();
   log.setLevel('trace');
 
-  // Create graph schemata
+  // Get graph schema IDs
   const schemaBuilder = new SchemaBuilder().withModelType('AvroBinary').withPayloadLocation('Paginated').withAutoDetectExistingSchema();
-  const publicFollowSchema = await schemaBuilder.withModel({ ...userPublicFollows, doc: 'Public follow schema' }).build(devAccounts[0].keys);
-  const publicFriendSchema = await schemaBuilder.withModel({ ...userPublicFollows, doc: 'Public friend schema' }).build(devAccounts[0].keys);
-  const privateFollowSchema = await schemaBuilder.withModel(userPrivateFollows).build(devAccounts[0].keys);
-  const privateFriendSchema = await schemaBuilder.withModel(userPrivateConnections).build(devAccounts[0].keys);
-  const publicKeySchema = await schemaBuilder.withPayloadLocation('Itemized').withModel(publicKey).withSetting('AppendOnly').build(devAccounts[0].keys);
+  const publicFollowSchema = await schemaBuilder
+    .withNamedVersion('dsnp.public-follows', 1)
+    .withModel({ ...userPublicFollows, doc: 'Public follow schema' })
+    .build(devAccounts[0].keys);
+  // const publicFriendSchema = await schemaBuilder
+  //   .withNamedVersion('dsnp.public-connections', 1)
+  //   .withModel({ ...userPublicFollows, doc: 'Public friend schema' })
+  //   .build(devAccounts[0].keys);
+  const privateFollowSchema = await schemaBuilder.withNamedVersion('dsnp.private-follows', 1).withModel(userPrivateFollows).build(devAccounts[0].keys);
+  const privateFriendSchema = await schemaBuilder.withNamedVersion('dsnp.private-connections', 1).withModel(userPrivateConnections).build(devAccounts[0].keys);
+  const publicKeySchema = await schemaBuilder
+    .withNamedVersion('dsnp.public-key-key-agreement', 1)
+    .withPayloadLocation('Itemized')
+    .withModel(publicKey)
+    .withSetting('AppendOnly')
+    .build(devAccounts[0].keys);
 
   const schemaMap: { [key: number]: SchemaConfig } = {};
   schemaMap[publicFollowSchema.id.toNumber()] = {
@@ -69,11 +82,11 @@ async function main() {
     connectionType: ConnectionType.Follow,
     privacyType: PrivacyType.Public,
   };
-  schemaMap[publicFriendSchema.id.toNumber()] = {
-    dsnpVersion: DsnpVersion.Version1_0,
-    connectionType: ConnectionType.Friendship,
-    privacyType: PrivacyType.Public,
-  };
+  // schemaMap[publicFriendSchema.id.toNumber()] = {
+  //   dsnpVersion: DsnpVersion.Version1_0,
+  //   connectionType: ConnectionType.Friendship,
+  //   privacyType: PrivacyType.Public,
+  // };
   schemaMap[privateFollowSchema.id.toNumber()] = {
     dsnpVersion: DsnpVersion.Version1_0,
     connectionType: ConnectionType.Follow,
@@ -84,26 +97,52 @@ async function main() {
     connectionType: ConnectionType.Friendship,
     privacyType: PrivacyType.Private,
   };
-  const environment: DevEnvironment = { environmentType: EnvironmentType.Dev, config: getTestConfig(schemaMap, publicKeySchema.id) };
+  // const environment: DevEnvironment = { environmentType: EnvironmentType.Dev, config: getTestConfig(schemaMap, publicKeySchema.id) };
+  const environment = { environmentType: EnvironmentType.Mainnet };
   const graph = new Graph(environment);
 
   // Fetch graphs
-  const bundleBuilder = new ImportBundleBuilder().withDsnpUserId(msaId.toString());
+  let bundleBuilder = new ImportBundleBuilder().withDsnpUserId(msaId.toString());
   const bundles: ImportBundle[] = [];
+
+  // Construct graph keys
+  if (!!publicGraphKeyHex && !!privateGraphKeyHex) {
+    const graphKeyPairsSdk: GraphKeyPair = {
+      keyType: GraphKeyType.X25519,
+      publicKey: hexToU8a(publicGraphKeyHex),
+      secretKey: hexToU8a(privateGraphKeyHex),
+    };
+    bundleBuilder = bundleBuilder.withGraphKeyPairs([graphKeyPairsSdk]);
+  }
+
+  // Fetch public key from chain
+  const publicKeys: ItemizedStoragePageResponse = await ExtrinsicHelper.apiPromise.rpc.statefulStorage.getItemizedStorage(msaId, publicKeySchema.id);
+  const keyData: KeyData[] = publicKeys.items.toArray().map((chainKey) => ({
+    index: chainKey.index.toNumber(),
+    content: hexToU8a(chainKey.payload.toHex()),
+  }));
+  const dsnpKeys: DsnpKeys = {
+    dsnpUserId: msaId,
+    keysHash: publicKeys.content_hash.toNumber(),
+    keys: keyData,
+  };
+  bundleBuilder = bundleBuilder.withDsnpKeys(dsnpKeys);
 
   // eslint-disable-next-line guard-for-in,no-restricted-syntax
   for (const schemaId in schemaMap) {
     const pages = await ExtrinsicHelper.apiPromise.rpc.statefulStorage.getPaginatedStorage(msaId, schemaId);
     const pageArray: PaginatedStorageResponse[] = pages.toArray();
 
-    let bb = bundleBuilder.withSchemaId(parseInt(schemaId, 10));
-    pageArray.forEach((page) => {
-      bb = bb.withPageData(page.page_id.toNumber(), page.payload, page.content_hash.toNumber());
-    });
-    bundles.push(bb.build());
+    if (pageArray.length > 0) {
+      let bb = bundleBuilder.withSchemaId(parseInt(schemaId, 10));
+      pageArray.forEach((page) => {
+        bb = bb.withPageData(page.page_id.toNumber(), page.payload, page.content_hash.toNumber());
+      });
+      bundles.push(bb.build());
+    }
   }
 
-  await graph.importUserData(bundles);
+  graph.importUserData(bundles);
 
   log.info(`
   Graph for MSA ${msaId}:
@@ -111,8 +150,8 @@ async function main() {
   // eslint-disable-next-line guard-for-in,no-restricted-syntax
   for (const schemaId in schemaMap) {
     const { connectionType, privacyType } = schemaMap[schemaId];
-    const connections = await graph.getConnectionsForUserGraph(msaId.toString(), parseInt(schemaId, 10), false);
-    log.info(`${connectionType}(${privacyType}) => ${JSON.stringify(connections.map((connection) => connection.userId))}`);
+    const connections = graph.getConnectionsForUserGraph(msaId.toString(), parseInt(schemaId, 10), true);
+    log.info(`${connectionType}(${privacyType}) => (${connections.length}) ${JSON.stringify(connections.map((connection) => connection.userId))}`);
   }
 }
 

--- a/src/scaffolding/schema.ts
+++ b/src/scaffolding/schema.ts
@@ -5,23 +5,35 @@ export type ModelTypeStr = 'AvroBinary' | 'Parquet';
 export type PayloadLocationStr = 'OnChain' | 'Ipfs' | 'Itemized' | 'Paginated';
 export type SchemaSettingStr = 'AppendOnly' | 'SignatureRequired';
 
-export class Schema {
-  private _id: SchemaId;
+export interface ISchema {
+  id: SchemaId;
+  model: object;
+  modelType: ModelTypeStr;
+  payloadLocation: PayloadLocationStr;
+  settings?: SchemaSettingStr[];
+  name?: string;
+}
 
-  private _model: {};
+export class Schema implements ISchema {
+  private readonly _id: SchemaId;
 
-  private _modelType: ModelTypeStr;
+  private readonly _model: {};
 
-  private _payloadLocation: PayloadLocationStr;
+  private readonly _modelType: ModelTypeStr;
 
-  private _settings: SchemaSettingStr[];
+  private readonly _payloadLocation: PayloadLocationStr;
 
-  constructor(id: SchemaId, model: {}, modelType: ModelTypeStr, payloadLocation: PayloadLocationStr, settings?: SchemaSettingStr[]) {
-    this._model = model;
-    this._modelType = modelType;
-    this._payloadLocation = payloadLocation;
-    this._settings = settings ?? [];
-    this._id = id;
+  private readonly _settings: SchemaSettingStr[];
+
+  private readonly _name: string | undefined;
+
+  constructor(source: ISchema) {
+    this._model = source.model;
+    this._modelType = source.modelType;
+    this._payloadLocation = source.payloadLocation;
+    this._settings = source?.settings ?? [];
+    this._id = source.id;
+    this._name = source?.name;
   }
 
   public get id() {
@@ -42,5 +54,9 @@ export class Schema {
 
   public get settings() {
     return this._settings;
+  }
+
+  public get name() {
+    return this?._name;
   }
 }


### PR DESCRIPTION
# Description
* Support schema names in `Schema` and `SchemaBuilder`
* Tweak the string output of `ExtrinsicError` and add a default stream method so that printing errors looks readable
* Support parsing & returning multiple events of the same type when parsing events generated by an extrinsic (useful for handling batch requests)
* Add schema name lookup and private graph key to `read_graph` example
* Update to GraphSDK `v1.1.1`
* Updates to `read-graph` example to support reading private graphs & looking up existing schema IDs