### PR TITLE
fix: move dep from dev to prod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "avsc": "^5.7.7",
         "loglevel": "^1.9.1",
         "minimist": "^1.2.8",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.1",
+        "unique-names-generator": "^4.7.1"
       },
       "devDependencies": {
         "@polkadot/typegen": "^11.2.1",
@@ -41,8 +42,7 @@
         "eslint-plugin-promise": "^6.2.0",
         "tsconfig-paths": "^4.2.0",
         "tsx": "^4.12.0",
-        "typescript": "^5.4.5",
-        "unique-names-generator": "^4.7.1"
+        "typescript": "^5.4.5"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -6816,7 +6816,6 @@
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/unique-names-generator/-/unique-names-generator-4.7.1.tgz",
       "integrity": "sha512-lMx9dX+KRmG8sq6gulYYpKWZc9RlGsgBR6aoO8Qsm3qvkSJ+3rAymr+TnV8EDMrIrwuFJ4kruzMWM/OpYzPoow==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "avsc": "^5.7.7",
     "loglevel": "^1.9.1",
     "minimist": "^1.2.8",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "unique-names-generator": "^4.7.1"
   },
   "devDependencies": {
     "@polkadot/typegen": "^11.2.1",
@@ -60,7 +61,6 @@
     "eslint-plugin-promise": "^6.2.0",
     "tsconfig-paths": "^4.2.0",
     "tsx": "^4.12.0",
-    "typescript": "^5.4.5",
-    "unique-names-generator": "^4.7.1"
+    "typescript": "^5.4.5"
   }
 }


### PR DESCRIPTION
# Description
Move the package dependency for `unique-names-generator` from `devDependencies` to `dependencies`; otherwise consuming packages break.