### PR TITLE
fix: weird import error in consuming packages from avsc import

### DIFF
--- a/src/scaffolding/schema.ts
+++ b/src/scaffolding/schema.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import { SchemaId } from '@frequency-chain/api-augment/interfaces';
-import { Type as AvroType, Schema as AvroSchema } from 'avsc';
+import avsc from 'avsc';
 
 export type ModelTypeStr = 'AvroBinary' | 'Parquet';
 export type PayloadLocationStr = 'OnChain' | 'Ipfs' | 'Itemized' | 'Paginated';
@@ -28,7 +28,7 @@ export class Schema implements ISchema {
 
   private readonly _name: string | undefined;
 
-  private _codec: AvroType | undefined; // TODO: add ParquetJS support
+  private _codec: avsc.Type | undefined; // TODO: add ParquetJS support
 
   constructor(source: ISchema) {
     this._model = source.model;
@@ -39,7 +39,7 @@ export class Schema implements ISchema {
     this._name = source?.name;
 
     if (this.modelType === 'AvroBinary') {
-      const avroModel: AvroSchema = (() => {
+      const avroModel: avsc.Schema = (() => {
         if (this.model?.toHuman) {
           return JSON.parse(this.model.toHuman());
         }
@@ -51,7 +51,7 @@ export class Schema implements ISchema {
         return this.model;
       })();
 
-      this._codec = AvroType.forSchema(avroModel);
+      this._codec = avsc.Type.forSchema(avroModel);
     }
   }
 

--- a/src/scenarios/provision-msas.ts
+++ b/src/scenarios/provision-msas.ts
@@ -86,7 +86,7 @@ export async function initializeLocalUsers(baseSeed: string, numUsers: number): 
  *
  * @returns {Promise<number>} Current block number
  */
-async function getCurrentBlockNumber(): Promise<number> {
+export async function getCurrentBlockNumber(): Promise<number> {
   const block = await ExtrinsicHelper.apiPromise.rpc.chain.getBlock();
   return block.block.header.number.toNumber();
 }
@@ -101,7 +101,12 @@ async function getCurrentBlockNumber(): Promise<number> {
  * @param {AnyNumber[]} schemaIds - Array of Schema IDs to be included in the Provider delegation
  * @returns {{ payload: PalletMsaAddProvider, proof: Sr25519Signature }}
  */
-function getAddProviderPayload(user: ChainUser, provider: ChainUser, currentBlockNumber: number, schemaIds: AnyNumber[]): { payload: AddProviderPayload; proof: Sr25519Signature } {
+export function getAddProviderPayload(
+  user: ChainUser,
+  provider: ChainUser,
+  currentBlockNumber: number,
+  schemaIds: AnyNumber[],
+): { payload: AddProviderPayload; proof: Sr25519Signature } {
   const mortalityWindowSize = ExtrinsicHelper.apiPromise.consts.msa.mortalityWindowSize.toNumber();
   const addProvider: AddProviderPayload = {
     authorizedMsaId: provider.msaId,
@@ -122,7 +127,7 @@ function getAddProviderPayload(user: ChainUser, provider: ChainUser, currentBloc
  * @param {number} currentBlockNumber Current block number used to calculate expiration of the payload signature
  * @returns {{ payload, proof: Sr25519Signature }}
  */
-function getClaimHandlePayload(user: ChainUser, handle: string, currentBlockNumber: number) {
+export function getClaimHandlePayload(user: ChainUser, handle: string, currentBlockNumber: number) {
   const mortalityWindowSize = ExtrinsicHelper.apiPromise.consts.msa.mortalityWindowSize.toNumber();
   const handleBytes = new Bytes(ExtrinsicHelper.apiPromise.registry, handle);
   const payload = {


### PR DESCRIPTION
# Description
Had to change the way the `Type` class from the `avsc` package was referenced, because some consuming packages threw a compile error on `import { Type } from 'avsc'`. Some weird ESM vs CommonJS issue?