### PR TITLE
fix errors from testing account service setup

### DIFF
--- a/src/scaffolding/extrinsicHelpers.ts
+++ b/src/scaffolding/extrinsicHelpers.ts
@@ -78,7 +78,7 @@ export class EventError extends Error {
 
   section?: string = '';
 
-  rawError: DispatchError | SpRuntimeDispatchError;
+  rawError: DispatchError | SpRuntimeDispatchError | any;
 
   method?: string = '';
 
@@ -99,7 +99,7 @@ export class EventError extends Error {
       this.message = source.type;
       this.section = '';
     }
-    this.rawError = source;
+    this.rawError = source?.toHuman ? source.toHuman() : source;
   }
 
   public toString() {

--- a/src/scaffolding/graph.ts
+++ b/src/scaffolding/graph.ts
@@ -9,16 +9,23 @@ import { Schema } from './schema.js';
 import { SchemaBuilder } from './schema-builder.js';
 import { Sr25519Signature, signPayloadSr25519 } from './helpers.js';
 
-// let publicGraphKeyAvroType: AvroType;
 let publicGraphKeySchema: Schema;
 
+/**
+ * Attempt to resolve the public graph key schema on-chain. Will first attempt to resolve
+ * using the schema name, and, failing that, will attempt to find a schema matching the data model
+ * (mostly useful for local dev chains not using a standard image, or Mainnet 1.12 which currently has a bug
+ * where the schema name is missing for this schema)
+ *
+ * NOTE: This method should be called before any other methods requiring the public graph key schema ID
+ *
+ * @returns {Promise<void>}
+ */
 export async function fetchPublicKeySchema(): Promise<void> {
   if (publicGraphKeySchema) {
     return;
   }
 
-  //   const pubKeySchemaIdResponse = await ExtrinsicHelper.apiPromise.query.schemas.schemaNameToIds('dsnp', 'public-key-key-agreement');
-  //   const schemaIds = pubKeySchemaIdResponse.ids.toArray();
   // Bug on mainnet: schema 7 (public key) not named; need to specify the complete model to resolve
   const schema = await new SchemaBuilder()
     .withName('dsnp', 'public-key-key-agreement')
@@ -28,9 +35,6 @@ export async function fetchPublicKeySchema(): Promise<void> {
     .withAutoDetectExistingSchema(true)
     .withSettings(['SignatureRequired', 'AppendOnly'])
     .resolve();
-  //   const { model }: SchemaResponse = (await ExtrinsicHelper.apiPromise.rpc.schemas.getBySchemaId(publicGraphKeySchemaId)).unwrap();
-  //   const modelObj = JSON.parse(model.toHuman() as string);
-  //   publicGraphKeyAvroType = AvroType.forSchema(modelObj);
   if (!schema) {
     throw new Error('dsnp.public-key-key-agreement schema not resolved');
   }
@@ -38,6 +42,14 @@ export async function fetchPublicKeySchema(): Promise<void> {
   publicGraphKeySchema = schema;
 }
 
+/**
+ * Fetch the current public graph key for a user, and return an array containing the key as
+ * a hex string and the current Itemized page hash. If no key currently provisioned, will
+ * return `[undefined, 0]`
+ *
+ * @param {AnyNumber} msaId MSA ID to retrieve public graph key for
+ * @returns {Promise<[HexString | undefined, number]>}
+ */
 export async function getCurrentPublicGraphKey(msaId: AnyNumber): Promise<[HexString | undefined, number]> {
   await fetchPublicKeySchema();
   const itemizedPageResponse: ItemizedStoragePageResponse = await ExtrinsicHelper.apiPromise.rpc.statefulStorage.getItemizedStorage(msaId, publicGraphKeySchema?.id);
@@ -49,6 +61,16 @@ export async function getCurrentPublicGraphKey(msaId: AnyNumber): Promise<[HexSt
   return [u8aToHex(publicKey), itemizedPageResponse.content_hash.toNumber()];
 }
 
+/**
+ * Create a signed payload for adding a new public graph key to a user's
+ * Itemized storage. Returns both the payload and the signature.
+ *
+ * @param {HexString} publicKey The public key to be provisioned
+ * @param {KeyringPair} signingKeys MSA keypair to sign the payload with
+ * @param {number} targetHash Last known content hash of the public key Itemized storage
+ * @param {number} currentBlock Last known "current" block number to be used for computing payload expiration
+ * @returns {Promise<{ payload: ItemizedSignaturePayload, proof: Sr25519Signature }>}
+ */
 export async function getAddGraphKeyPayload(
   publicKey: HexString,
   signingKeys: KeyringPair,

--- a/src/scaffolding/transactions.ts
+++ b/src/scaffolding/transactions.ts
@@ -2,13 +2,13 @@ import { FrameSystemEventRecord } from '@polkadot/types/lookup';
 import { Vec } from '@polkadot/types-codec';
 import { AugmentedSubmittable, SubmittableExtrinsic, VoidFn } from '@polkadot/api/types';
 import { IMethod, ISubmittableResult } from '@polkadot/types/types';
-import { Call } from '@polkadot/types/interfaces';
+import { Call, EventRecord } from '@polkadot/types/interfaces';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { EventError, ExtrinsicHelper } from './extrinsicHelpers.js';
 
-export type ChainEventHandler = (events: Vec<FrameSystemEventRecord>) => void;
+export type ChainEventHandler = (events: Vec<FrameSystemEventRecord> | EventRecord[]) => void;
 
-export interface PromiseTracker {
+interface PromiseTracker {
   resolve?: () => void;
   reject?: (reason?: any) => void;
   promise?: Promise<void>;
@@ -16,23 +16,19 @@ export interface PromiseTracker {
 }
 
 const batchesTracker: PromiseTracker = { numPending: 0 };
-let unsubEvents: VoidFn = () => {};
 
-function watchAndHandleChainEvents(handlers: ChainEventHandler[]): Promise<VoidFn> {
-  return ExtrinsicHelper.apiPromise.query.system.events((events: Vec<FrameSystemEventRecord>) => {
-    events.forEach((eventRecord) => {
-      const { event } = eventRecord;
-      if (ExtrinsicHelper.apiPromise.events.utility.BatchCompleted.is(event)) {
-        batchesTracker.numPending -= 1;
-        if (batchesTracker.numPending < 1) {
-          batchesTracker.numPending = 0;
-          (batchesTracker?.resolve ?? (() => {}))();
-        }
+const defaultEventHandler = (events: EventRecord[]) => {
+  events.forEach((eventRecord) => {
+    const { event } = eventRecord;
+    if (ExtrinsicHelper.apiPromise.events.utility.BatchCompleted.is(event) || ExtrinsicHelper.apiPromise.events.system.ExtrinsicFailed.is(event)) {
+      batchesTracker.numPending -= 1;
+      if (batchesTracker.numPending < 1) {
+        batchesTracker.numPending = 0;
+        (batchesTracker?.resolve ?? (() => {}))();
       }
-    });
-    handlers.forEach((handler) => handler(events));
+    }
   });
-}
+};
 
 async function batchAndWaitForExtrinsics(
   payorKeys: KeyringPair,
@@ -40,12 +36,12 @@ async function batchAndWaitForExtrinsics(
   handlers: ChainEventHandler[],
   batchAll: AugmentedSubmittable<(calls: Vec<Call> | (Call | IMethod | string | Uint8Array)[]) => SubmittableExtrinsic<'promise'>, [Vec<Call>]>,
 ) {
+  // TODO: use Promise.withResolvers in Node.js >= 22.x
   batchesTracker.promise = new Promise((resolve, reject) => {
     batchesTracker.resolve = resolve;
     batchesTracker.reject = reject;
     batchesTracker.numPending = 0;
   });
-  unsubEvents = await watchAndHandleChainEvents(handlers);
 
   const unsubBlocks = await ExtrinsicHelper.apiPromise.rpc.chain.subscribeFinalizedHeads(() => {
     const count = extrinsics.length + batchesTracker.numPending;
@@ -59,24 +55,32 @@ async function batchAndWaitForExtrinsics(
   let nonce = (await ExtrinsicHelper.apiPromise.query.system.account(payorKeys.publicKey)).nonce.toNumber();
 
   while (extrinsics.length > 0) {
+    // We don't want to exceed the size limit for the future pool
+    // TODO: retrieve a sane value for this
     if (batchesTracker.numPending < 100) {
-      // so we don't DOS the node
       const xToPost = extrinsics.splice(0, maxBatch);
       batchesTracker.numPending += 1;
-      // eslint-disable-next-line no-await-in-loop, no-plusplus
-      const unsub = await batchAll(xToPost).signAndSend(payorKeys, { nonce: nonce++ }, (x) => {
-        const { status } = x;
-        if (x.dispatchError) {
-          unsub();
-          (batchesTracker.reject ?? (() => {}))(new EventError(x.dispatchError));
-        } else if (status.isInvalid) {
-          unsub();
-          console.error(x.toHuman());
-          (batchesTracker?.reject ?? (() => {}))(new Error('Extrinsic failed: Invalid'));
-        } else if (x.isFinalized) {
-          unsub();
-        }
-      });
+      try {
+        // eslint-disable-next-line no-await-in-loop, no-plusplus
+        const unsub = await batchAll(xToPost).signAndSend(payorKeys, { nonce: nonce++ }, (x) => {
+          const { status, events } = x;
+          if (x.dispatchError) {
+            unsub();
+            (batchesTracker.reject ?? (() => {}))(new EventError(x.dispatchError));
+          } else if (status.isInvalid) {
+            unsub();
+            console.error(x.toHuman());
+            (batchesTracker?.reject ?? (() => {}))(new Error('Extrinsic failed: Invalid'));
+          } else if (x.isFinalized) {
+            unsub();
+          }
+
+          defaultEventHandler(events);
+          handlers.forEach((handler) => handler(events));
+        });
+      } catch (err: any) {
+        throw new Error('Error submitting batch to the chain', { cause: err });
+      }
     } else {
       // eslint-disable-next-line no-await-in-loop
       await batchesTracker.promise;
@@ -88,7 +92,6 @@ async function batchAndWaitForExtrinsics(
   }
 
   await batchesTracker.promise;
-  unsubEvents();
 }
 
 export async function batchWithUtilityAndWaitForExtrinsics(
@@ -102,7 +105,7 @@ export async function batchWithUtilityAndWaitForExtrinsics(
 export async function batchWithCapacityAndWaitForExtrinsics(
   payorKeys: KeyringPair,
   extrinsics: SubmittableExtrinsic<'promise', ISubmittableResult>[],
-  handlers: ((events: Vec<FrameSystemEventRecord>) => void)[],
+  handlers: ChainEventHandler[],
 ) {
   return batchAndWaitForExtrinsics(payorKeys, extrinsics, handlers, ExtrinsicHelper.apiPromise.tx.frequencyTxPayment.payWithCapacityBatchAll);
 }

--- a/src/scaffolding/user-builder.ts
+++ b/src/scaffolding/user-builder.ts
@@ -141,9 +141,12 @@ export class UserBuilder {
       try {
         log.info(`Funding account ${this.defaultKeypair.address} with ${fundingAmount > EXISTENTIAL_DEPOSIT ? fundingAmount : 'existential deposit'}`);
         await ExtrinsicHelper.transferFunds(fundingSource, this.defaultKeypair, fundingAmount).signAndSend();
-      } catch (e) {
-        throw new Error(`Unable to transfer initial token amount ${fundingAmount.toString()}:
-            ${JSON.stringify(e)}`);
+      } catch (e: any) {
+        throw new Error(
+          `Unable to transfer initial token amount ${fundingAmount.toString()}:
+            ${e?.toString() || e?.message || JSON.stringify(e)}`,
+          { cause: e },
+        );
       }
     }
 


### PR DESCRIPTION
# Description
In the process of testing the latest version of this package in the chain-setup for [account-service](https://github.com/AmplicaLabs/account-service), some bugs were found. This PR does the following:

- More readable error message when failing to fund an account properly in `UserBuilder.build()`
- In `transactions.ts`, when looking for completed transactions we were subscribing to all chain events via the system RPC, which could get events from extrinsics not submitted by us. Instead, process the events inside the transaction subscription itself.
- `schema_id` & `target_hash` had been hard-coded when provisioning graph public keys; instead, use the detected values
- Make `EventError` more readable
